### PR TITLE
Improve movie show specs

### DIFF
--- a/spec/features/00_movies_gui_spec.rb
+++ b/spec/features/00_movies_gui_spec.rb
@@ -64,9 +64,18 @@ end
 
 describe "/movies/[ID]" do
   it "displays the title of the movie", :points => 1 do
+    director = Director.new
+    director.name = "Scout Young"
+    director.dob = 27.years.ago
+    director.image = ""
+    director.save
 
     movie = Movie.new
     movie.title = "Flubber"
+    movie.director_id = director.id
+    movie.year = 1999
+    movie.description = "Just a green lil' guy"
+    movie.duration = 95
     movie.save
 
     visit "/movies/#{movie.id}"
@@ -77,9 +86,18 @@ end
 
 describe "/delete_movie/[PHOTO ID]" do
   it "removes a record from the Movie table", :points => 1 do
+    director = Director.new
+    director.name = "Scout Young"
+    director.dob = 27.years.ago
+    director.image = ""
+    director.save
 
     movie = Movie.new
     movie.title = "Flubber"
+    movie.director_id = director.id
+    movie.year = 1999
+    movie.description = "Just a green lil' guy"
+    movie.duration = 95
     movie.save
 
     visit "/delete_movie/#{movie.id}"
@@ -90,9 +108,19 @@ end
 
 describe "/delete_movie/[PHOTO ID]" do
   it "redirects to /movies", :points => 1, hint: h("redirect_vs_render") do
+    director = Director.new
+    director.name = "Scout Young"
+    director.dob = 27.years.ago
+    director.image = ""
+    director.save
 
     movie = Movie.new
     movie.title = "Flubber"
+    movie.director_id = director.id
+    movie.year = 1999
+    movie.description = "Just a green lil' guy"
+    movie.duration = 95
+    movie.year = 1999
     movie.save
 
     visit "/delete_movie/#{movie.id}"
@@ -103,9 +131,19 @@ end
 
 describe "/movies/[ID]" do
   it "has at least one form", :points => 1 do
+    director = Director.new
+    director.name = "Scout Young"
+    director.dob = 27.years.ago
+    director.image = ""
+    director.save
 
     movie = Movie.new
     movie.title = "Flubber"
+    movie.director_id = director.id
+    movie.year = 1999
+    movie.description = "Just a green lil' guy"
+    movie.duration = 95
+    movie.year = 1999
     movie.save
 
     visit "/movies/#{movie.id}"
@@ -116,7 +154,12 @@ end
 
 describe "/movies/[ID]" do
   it "has a label with text 'Image'", :points => 1, hint: h("copy_must_match label_for_input") do
- 
+    director = Director.new
+    director.name = "Scout Young"
+    director.dob = 27.years.ago
+    director.image = ""
+    director.save
+
     movie = Movie.new
     movie.title = "Flubber"
     movie.image = "https://some.test/image-#{Time.now.to_i}.jpg"
@@ -131,6 +174,11 @@ end
 
 describe "/movies/[ID]" do
   it "has a button with text 'Update movie'", :points => 1, hint: h("copy_must_match label_for_input") do
+    director = Director.new
+    director.name = "Scout Young"
+    director.dob = 27.years.ago
+    director.image = ""
+    director.save
 
     movie = Movie.new
     movie.title = "Flubber"
@@ -146,6 +194,11 @@ end
 
 describe "/movies/[ID]" do
   it "'Update movie' form has Image prepopulated in an input element", :points => 1, hint: h("value_attribute") do
+    director = Director.new
+    director.name = "Scout Young"
+    director.dob = 27.years.ago
+    director.image = ""
+    director.save
 
     movie = Movie.new
     movie.title = "Flubber"
@@ -161,6 +214,11 @@ end
 
 describe "/movies/[ID]" do
   it "'Update movie' form updates Image when submitted", :points => 1, hint: h("label_for_input button_type") do
+    director = Director.new
+    director.name = "Scout Young"
+    director.dob = 27.years.ago
+    director.image = ""
+    director.save
 
     movie = Movie.new
     movie.title = "Flubber"
@@ -182,6 +240,11 @@ end
 
 describe "/movies/[ID]" do
   it "'Update movie' form redirects to the movie's details page when updating movie", :points => 1, hint: h("embed_vs_interpolate redirect_vs_render") do
+    director = Director.new
+    director.name = "Scout Young"
+    director.dob = 27.years.ago
+    director.image = ""
+    director.save
 
     movie = Movie.new
     movie.title = "Flubber"

--- a/spec/features/03_movies_spec.rb
+++ b/spec/features/03_movies_spec.rb
@@ -206,7 +206,7 @@ describe "/movies/[MOVIE ID]" do
     deep_impact.title = "Deep Impact"
     deep_impact.description = "It's like evangelion."
     deep_impact.year = 1999
-    movie.duration = 95
+    deep_impact.duration = 95
     deep_impact.director_id = director.id
     deep_impact.save
 

--- a/spec/features/03_movies_spec.rb
+++ b/spec/features/03_movies_spec.rb
@@ -206,7 +206,7 @@ describe "/movies/[MOVIE ID]" do
     deep_impact.title = "Deep Impact"
     deep_impact.description = "It's like evangelion."
     deep_impact.year = 1999
-    deep_impact.duration = 95
+    movie.duration = 95
     deep_impact.director_id = director.id
     deep_impact.save
 


### PR DESCRIPTION
- tests could fail if they displayed the director name, because the tests previously did not create an associated director